### PR TITLE
Add docker-compose for chef

### DIFF
--- a/minimal_vscode/dumplings/README.md
+++ b/minimal_vscode/dumplings/README.md
@@ -23,3 +23,9 @@ chef serve --port 8000 --path .
 ```bash
 chef recipe <RECIPE_NAME>
 ```
+
+Или можно запустить UI в докере:
+
+```bash
+docker compose up
+```

--- a/minimal_vscode/dumplings/docker-compose.yaml
+++ b/minimal_vscode/dumplings/docker-compose.yaml
@@ -1,0 +1,19 @@
+services:
+  chef:
+    ports:
+      - 8000:8000
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM rust:latest
+
+        RUN cargo install \
+          --git https://github.com/Zheoni/cooklang-chef \
+          --tag "v0.10.1" \
+          --locked
+
+        WORKDIR /dumplings
+
+        COPY . .
+
+        CMD ["chef", "serve", "--host", "--port", "8000", "--path", "."]


### PR DESCRIPTION
Добавил минимальный конфиг докер компоуза, чтобы пользователи без карго могли запустить chef и посмотреть рецепты пельменей